### PR TITLE
Prevent Use of Wrong Data After Deletion

### DIFF
--- a/GH Injector Library/Tools.cpp
+++ b/GH Injector Library/Tools.cpp
@@ -1,6 +1,6 @@
 /*
  * Author:       Broihon
- * Copyright:    Guided Hacking™ © 2012-2023 Guided Hacking LLC
+ * Copyright:    Guided Hackingâ„¢ Â© 2012-2023 Guided Hacking LLC
 */
 
 #include "pch.h"
@@ -154,15 +154,16 @@ DWORD ValidateDllFile(const std::wstring & FilePath, DWORD target_machine)
 		return FILE_ERR_INVALID_FILE;
 	}
 
-	delete[] headers;
-
 	if (nt_headers->FileHeader.Machine != target_machine)
 	{
 		LOG(1, "DLL platform mismatch\n");
+		
+		delete[] headers;
 
 		return FILE_ERR_INVALID_FILE;
 	}
 
+	delete[] headers;
 	return FILE_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
This pull request addresses an issue where the delete[] headers; statement was positioned incorrectly, potentially leading to the use of invalid data after deletion. The change reorders the statements to ensure that headers is deleted before returning FILE_ERR_INVALID_FILE to avoid using the deleted data.